### PR TITLE
Change `Launcher.ExecuteInMainContext` to be blocking

### DIFF
--- a/src/Nightglow/Common/Launcher.cs
+++ b/src/Nightglow/Common/Launcher.cs
@@ -73,8 +73,7 @@ public abstract class Launcher {
     /// Does not block.
     /// </summary>
     /// <param name="action">the delegate to be executed</param>
-    public static void ExecuteInMainContextNonBlocking(Action action)
-    {
+    public static void ExecuteInMainContextNonBlocking(Action action) {
         if (Context != null)
             Context.Post(_ => action(), null);
         else

--- a/src/Nightglow/Common/Launcher.cs
+++ b/src/Nightglow/Common/Launcher.cs
@@ -46,7 +46,35 @@ public abstract class Launcher {
         }
     }
 
+    /// <summary>
+    /// Executes a delegate in the main GTK context.
+    /// Blocks until the action has completed.
+    /// </summary>
+    /// <param name="action">the delegate to be executed</param>
     public static void ExecuteInMainContext(Action action) {
+        using ManualResetEventSlim resetEvent = new ManualResetEventSlim(false);
+
+        if (Context != null)
+            Context.Post(_ => {
+                action();
+                resetEvent.Set();
+            }, null);
+        else
+            Task.Factory.StartNew(() => {
+                action();
+                resetEvent.Set();
+            });
+
+        resetEvent.Wait();
+    }
+
+    /// <summary>
+    /// Executes a delegate in the main GTK context.
+    /// Does not block.
+    /// </summary>
+    /// <param name="action">the delegate to be executed</param>
+    public static void ExecuteInMainContextNonBlocking(Action action)
+    {
         if (Context != null)
             Context.Post(_ => action(), null);
         else

--- a/src/Nightglow/UI/UILauncher.cs
+++ b/src/Nightglow/UI/UILauncher.cs
@@ -10,7 +10,6 @@ namespace Nightglow.UI;
 public class UILauncher : Launcher {
     public Gtk.Application Application = null!;
     public Window MainWindow = null!; // This could probably just be combined into one class with UILauncher...
-    private readonly ManualResetEvent ProgressDiaglogEvent = new ManualResetEvent(false); // MRE to prevent NewProgressDialog from returning before the enqueued main thread action finishes
 
     // This is kind of a hack. I shouldn't need to do this. Someone find a better way to do this.
     // The reason why I can't just pass it in via a constructor is because I need to construct it before creating
@@ -33,20 +32,11 @@ public class UILauncher : Launcher {
         IProgressDialog? dialog = null;
 
         if (Environment.CurrentManagedThreadId != 1) {
-            ProgressDiaglogEvent.Reset();
-
             ExecuteInMainContext(() => {
                 dialog = new UIProgressDialog(Application, MainWindow);
                 dialog.Initialize(title, header, text, opts);
-
-                // Signal that we have instantiated and initialized the dialog
-                ProgressDiaglogEvent.Set();
             });
 
-            // Wait for ProgressDiaglogEvent.Set to be called
-            ProgressDiaglogEvent.WaitOne();
-
-            // Sanity check
             if (dialog == null) {
                 throw new Exception();
             }
@@ -56,6 +46,6 @@ public class UILauncher : Launcher {
             dialog.Initialize(title, header, text, opts);
         }
 
-        return dialog!;
+        return dialog;
     }
 }


### PR DESCRIPTION
`Launcher.ExecuteInMainContext` was previously non-blocking, forcing any call of it that needed to wait for say, a resource or dialog to be created, to block.
This changes the behavior of `Launcher.ExecuteInMainContext` to block the execution of the current thread until the delegate finishes executing.
This also adds a separate `Launcher.ExecuteInMainContextNonBlocking` function which has the same behavior of the previous function.